### PR TITLE
Add is error to event

### DIFF
--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -153,7 +153,7 @@ public enum CommandError: Error, CustomStringConvertible, Sendable {
     }
 }
 
-public struct CommandRunner: Sendable {
+public struct CommandRunner: CommandRunning, Sendable {
     let logger: Logger?
 
     public init(logger: Logger? = nil) {

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -130,6 +130,13 @@ public enum CommandEvent: Sendable {
             String(decoding: bytes, as: Unicode.UTF8.self)
         }
     }
+
+    public var isError: Bool {
+        switch self {
+        case .standardError: true
+        default: false
+        }
+    }
 }
 
 public enum CommandError: Error, CustomStringConvertible, Sendable {

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -133,7 +133,7 @@ public enum CommandEvent: Sendable {
     public var isError: Bool {
         switch self {
         case .standardError: true
-        default: false
+        case .standardOutput: false
         }
     }
 }

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -124,9 +124,8 @@ public enum CommandEvent: Sendable {
 
     public var utf8String: String {
         switch self {
-        case let .standardOutput(bytes):
-            String(decoding: bytes, as: Unicode.UTF8.self)
-        case let .standardError(bytes):
+        case let .standardOutput(bytes),
+             let .standardError(bytes):
             String(decoding: bytes, as: Unicode.UTF8.self)
         }
     }

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,3 +1,8 @@
 import ProjectDescription
 
-let config = Config(cloud: .cloud(projectId: "tuist/command"))
+let config = Config(
+    fullHandle: "tuist/command",
+    generationOptions: .options(
+        optionalAuthentication: true
+    )
+)


### PR DESCRIPTION
When checking out Command, I noticed a few tiny things that could be improved, including a change in Config.swift:

* Add `isError` property to `CommandEvent`
* Add CommandRunning conformance to CommandRunner
* Unify switch case statements in CommandEvent utf8String
* Update Config.swift to latest Config API