### PR TITLE
feat: add a convenient API to concatenate the output from standard pipelines

### DIFF
--- a/Sources/Command/AsyncThrowingStream+Extras.swift
+++ b/Sources/Command/AsyncThrowingStream+Extras.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension AsyncThrowingStream where Element == CommandEvent {
+    /// It concatenates the stdout and stderr events encoded as strings using the provided encoding.
+    /// - Parameter encoding: The encoding to use. When absent, it defaults to UTF-8.
+    /// - Returns: The result of concatenating all the strings.
+    public func concatenatedString(
+        including: Set<CommandEvent.Pipeline> = Set([.standardError, .standardOutput]),
+        encoding: String.Encoding = .utf8
+    ) async throws -> String {
+        try await reduce(into: "") { acc, event in
+            if including.contains(event.pipeline) {
+                acc.append(event.string(encoding: encoding) ?? "")
+            }
+        }
+    }
+}

--- a/Tests/CommandTests/AsyncThrowingStream+ExtrasTests.swift
+++ b/Tests/CommandTests/AsyncThrowingStream+ExtrasTests.swift
@@ -1,0 +1,18 @@
+import Command
+import Foundation
+import XCTest
+
+public final class AsyncThrowingStreamExtrasTests: XCTestCase {
+    func test_concatenatedString_returnsTheConcatenatedString() async throws {
+        // Given
+        let commandRunner = CommandRunner()
+
+        // When
+        let result = try await commandRunner
+            .run(arguments: ["echo", "foo"])
+            .concatenatedString().trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Then
+        XCTAssertEqual(result, "foo")
+    }
+}

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -7,7 +7,7 @@ final class CommandTests: XCTestCase {
         let commandRunner = CommandRunner()
 
         // When
-        let result = try await commandRunner.run(arguments: ["echo", "foo"]).reduce(into: [String]()) { $0.append($1.utf8String) }
+        let result = try await commandRunner.run(arguments: ["echo", "foo"]).reduce(into: [String]()) { $0.append($1.string()) }
 
         // Then
         XCTAssertEqual(result, ["foo\n"])


### PR DESCRIPTION
I'm adding a convenient API to concatenate the output from the `AsyncThrowingStream<CommandEvent>`. This is useful in scenarios where the caller is only interested in the output (e.g. when running `swift version`).
I've taken the opportunity to add some `log.debug` to facilitate debugging to the users of the consumer packages/projects.