### PR TITLE
feat: not resolve executables that are already passed as absolute paths

### DIFF
--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -273,6 +273,12 @@ public struct CommandRunner: CommandRunning, Sendable {
 
     fileprivate func lookupExecutable(firstArgument: String?) throws -> URL? {
         guard let firstArgument else { return nil }
+
+        // If the first argument is an absolute URL to an executable, return it.
+        if let executablePath = try? Path.AbsolutePath(validating: firstArgument) {
+            return URL(fileURLWithPath: executablePath.pathString)
+        }
+
         let command: String
         let arguments: [String]
 

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -165,7 +165,7 @@ public struct CommandRunner: CommandRunning, Sendable {
 
     public func run(
         arguments: [String],
-        environment _: [String: String] = ProcessInfo.processInfo.environment,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
         workingDirectory: Path.AbsolutePath? = nil,
         startNewProcessGroup _: Bool = false,
         log _: Bool = false
@@ -214,6 +214,7 @@ public struct CommandRunner: CommandRunning, Sendable {
                     process.standardOutput = stdoutPipe
                     process.standardError = stderrPipe
                     process.arguments = Array(arguments.dropFirst())
+                    process.environment = environment
                     process.executableURL = try lookupExecutable(firstArgument: arguments.first)
 
                     let threadSafeProcess = ThreadSafe(process)

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -175,7 +175,7 @@ public struct CommandRunner: CommandRunning, Sendable {
 
                     let processArguments = Array(arguments.dropFirst())
                     process.arguments = processArguments
-                    
+
                     let executable = try lookupExecutable(firstArgument: arguments.first)
                     process.executableURL = executable
 
@@ -238,7 +238,7 @@ public struct CommandRunner: CommandRunning, Sendable {
         }
     }
 
-    fileprivate func lookupExecutable(firstArgument: String?) throws -> URL? {
+    internal func lookupExecutable(firstArgument: String?) throws -> URL? {
         guard let firstArgument else { return nil }
 
         // If the first argument is an absolute URL to an executable, return it.

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -238,7 +238,7 @@ public struct CommandRunner: CommandRunning, Sendable {
         }
     }
 
-    internal func lookupExecutable(firstArgument: String?) throws -> URL? {
+    func lookupExecutable(firstArgument: String?) throws -> URL? {
         guard let firstArgument else { return nil }
 
         // If the first argument is an absolute URL to an executable, return it.

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -12,4 +12,37 @@ final class CommandTests: XCTestCase {
         // Then
         XCTAssertEqual(result, ["foo\n"])
     }
+
+    func test_lookupExecutable_withAbsolutePath() throws {
+        // Given
+        let commandRunner = CommandRunner()
+        let absolutePath = "/bin/echo"
+
+        // When
+        let executableURL = try commandRunner.lookupExecutable(firstArgument: absolutePath)
+
+        // Then
+        XCTAssertEqual(executableURL?.path, absolutePath)
+    }
+
+    func test_lookupExecutable_withRegularCommand() throws {
+        // Given
+        let commandRunner = CommandRunner()
+        let command = "echo"
+
+        // When
+        let executableURL = try commandRunner.lookupExecutable(firstArgument: command)
+
+        // Then
+        XCTAssertNotNil(executableURL)
+        XCTAssertTrue(executableURL?.path.contains("/echo") ?? false)
+    }
+
+    func test_lookupExecutable_withInvalidCommand() throws {
+        // Given
+        let commandRunner = CommandRunner()
+        let command = "nonexistentcommand"
+
+        XCTAssertNil(try commandRunner.lookupExecutable(firstArgument: command))
+    }
 }

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -35,7 +35,7 @@ final class CommandTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(executableURL)
-        XCTAssertTrue(executableURL?.path.contains("/echo") ?? false)
+        XCTAssertTrue(executableURL!.path.hasSuffix("/echo"))
     }
 
     func test_lookupExecutable_withInvalidCommand() throws {

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -43,6 +43,10 @@ final class CommandTests: XCTestCase {
         let commandRunner = CommandRunner()
         let command = "nonexistentcommand"
 
-        XCTAssertNil(try commandRunner.lookupExecutable(firstArgument: command))
+        // When
+        let executableURL = try commandRunner.lookupExecutable(firstArgument: command)
+
+        // Then
+        XCTAssertNil(executableURL)
     }
 }

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -35,7 +35,7 @@ final class CommandTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(executableURL)
-        XCTAssertTrue(executableURL!.path.hasSuffix("/echo"))
+        XCTAssertTrue(executableURL!.path.hasSuffix("/\(command)"))
     }
 
     func test_lookupExecutable_withInvalidCommand() throws {


### PR DESCRIPTION
- Detect an absolute executable path
- Properly set environment