### PR TITLE
fix: lookupExecutable race condition

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "42117a24adae9d77816b090d33a4ef9548125c0f3ef95e49547663ad6064444d",
+  "originHash" : "346525d1087751bbdce931b44a043368833b77cb6295f31ab26d229cb8e18b9a",
   "pins" : [
     {
       "identity" : "path",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Path",
       "state" : {
-        "revision" : "4490da629937fc3994f72dd787dcc3f50d6973fe",
-        "version" : "0.3.0"
+        "revision" : "f63466272e0ae49b0ab6228afe39b113c98f350a",
+        "version" : "0.3.2"
       }
     },
     {

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -22,7 +22,7 @@ final class CommandTests: XCTestCase {
         let executableURL = try commandRunner.lookupExecutable(firstArgument: absolutePath)
 
         // Then
-        XCTAssertEqual(executableURL?.path, absolutePath)
+        XCTAssertEqual(executableURL.path, absolutePath)
     }
 
     func test_lookupExecutable_withRegularCommand() throws {
@@ -34,8 +34,7 @@ final class CommandTests: XCTestCase {
         let executableURL = try commandRunner.lookupExecutable(firstArgument: command)
 
         // Then
-        XCTAssertNotNil(executableURL)
-        XCTAssertTrue(executableURL!.path.hasSuffix("/\(command)"))
+        XCTAssertTrue(executableURL.path.hasSuffix("/\(command)"))
     }
 
     func test_lookupExecutable_withInvalidCommand() throws {
@@ -43,10 +42,7 @@ final class CommandTests: XCTestCase {
         let commandRunner = CommandRunner()
         let command = "nonexistentcommand"
 
-        // When
-        let executableURL = try commandRunner.lookupExecutable(firstArgument: command)
-
-        // Then
-        XCTAssertNil(executableURL)
+        // When & Then
+        XCTAssertThrowsError(try commandRunner.lookupExecutable(firstArgument: command))
     }
 }


### PR DESCRIPTION
I was seeing inconsistent behavior in `lookupExectuable` do to a race condition where the data was read before waiting for the task to finish.

This PR fixes the race condition by ensuring we wait for process exit before attempting to read data from the pipe