### PR TITLE
feat: add Mockable to ease mocking dowstream

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "346525d1087751bbdce931b44a043368833b77cb6295f31ab26d229cb8e18b9a",
+  "originHash" : "200d1eaa111ffca8244a8c1f89ae2c31d498101126538b7a0848d53fbc97ad01",
   "pins" : [
+    {
+      "identity" : "mockable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kolos65/Mockable",
+      "state" : {
+        "revision" : "da977ecb20974c4b1cf185f5fd38771b2d4674fb",
+        "version" : "0.0.10"
+      }
+    },
     {
       "identity" : "path",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Path",
       "state" : {
-        "revision" : "f63466272e0ae49b0ab6228afe39b113c98f350a",
-        "version" : "0.3.2"
+        "revision" : "25b8619f75e3d2141940a64a7b870d893164c352",
+        "version" : "0.3.3"
       }
     },
     {
@@ -17,6 +26,15 @@
       "state" : {
         "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.3")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
+        .package(url: "https://github.com/Kolos65/Mockable", .upToNextMajor(from: "0.0.10")),
     ],
     targets: [
         .target(
@@ -23,9 +24,11 @@ let package = Package(
             dependencies: [
                 .product(name: "Path", package: "Path"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Mockable", package: "Mockable"),
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
+                .define("MOCKING", .when(configuration: .debug)),
             ]
         ),
         .testTarget(

--- a/Project.swift
+++ b/Project.swift
@@ -13,11 +13,14 @@ let project = Project(name: "Command", targets: [
         dependencies: [
             .external(name: "Logging"),
             .external(name: "Path"),
+            .external(name: "Mockable"),
         ],
         settings: .settings(
             base: ["SWIFT_STRICT_CONCURRENCY": "complete"],
             configurations: [
-                .debug(name: .debug, settings: [:]),
+                .debug(name: .debug, settings: [
+                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
+                ]),
                 .release(name: .release, settings: [:]),
             ]
         )

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -1,11 +1,13 @@
 import Foundation
 import Logging
+import Mockable
 import Path
 
 /**
  `CommandRunning` is a protocol that declares the interface to run system processes.
  The main implementation of the protocol is `CommandRunner`.
  */
+@Mockable
 public protocol CommandRunning: Sendable {
     /// Runs a command in the system.
     /// - Parameters:


### PR DESCRIPTION
I'm adding [Mockable](https://github.com/Kolos65/Mockable) as a development dependency to ease mocking the implementation in downstream tests.