### PR TITLE
feat: Default to inheriting the standard input from the current process

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -16,3 +16,5 @@ jobs:
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitTitleMatch: "false"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "200d1eaa111ffca8244a8c1f89ae2c31d498101126538b7a0848d53fbc97ad01",
+  "originHash" : "7a136b218ee7e61a27a7b266e1035e0d961ca89a3c56036659d9a2e490754b04",
   "pins" : [
     {
       "identity" : "mockable",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Path",
       "state" : {
-        "revision" : "25b8619f75e3d2141940a64a7b870d893164c352",
-        "version" : "0.3.3"
+        "revision" : "7c74ac435e03a927c3a73134c48b61e60221abcb",
+        "version" : "0.3.8"
       }
     },
     {

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -175,6 +175,7 @@ public struct CommandRunner: CommandRunning, Sendable {
                     process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory!.pathString)
                     process.standardOutput = stdoutPipe
                     process.standardError = stderrPipe
+                    process.standardInput = FileHandle.standardInput
                     process.environment = environment
 
                     let processArguments = Array(arguments.dropFirst())


### PR DESCRIPTION
I noticed when I run `tuist` through `tuist` with `tuist run`, the interactive components, which require standard input, don't work. It turns out that `Command` is not passing the standard input of the current process down to the spawned process.
This PR fixes it by setting it when creating the instance of `Process`.

> [!NOTE]
> This is, in theory, a breaking change, but since we are still under 1.0, and it's, in fact, not that breaking, I think it's fair to ship it as such. Let me know if you have a different opinion.