### PR TITLE
Configure git-cliff to skip `chore(deps)` PRs/commits

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -84,8 +84,23 @@ filter_unconventional = true
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-  # remove issue numbers from commits
-  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+    # remove issue numbers from commits
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+    { body = ".*security", group = "Security" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
@@ -104,5 +119,5 @@ sort_commits = "newest"
 
 [bump]
 breaking_always_bump_major = true
-features_always_bump_minor=true
-initial_tag="0.2.1"
+features_always_bump_minor = true
+initial_tag = "0.2.1"

--- a/cliff.toml
+++ b/cliff.toml
@@ -95,6 +95,7 @@ commit_parsers = [
     { message = "^refactor", group = "Refactor" },
     { message = "^style", group = "Styling" },
     { message = "^test", group = "Testing" },
+    { message = "^chore\\(spm.*\\)", skip = false },
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,12 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "auto"
+      "automergeStrategy": "auto",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["swift"],
+      "semanticCommitScope": "spm"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
I'm configuring `git-cliff` to skip the `chore(deps)` PRs created by renovatebot. I used [this configuration](https://github.com/orhun/git-cliff/blob/f29e8150a8166d7364ed71b24675136d2e9bd382/examples/detailed.toml#L47C1-L61C2) as a reference.