### PR TITLE
fix: data race running many processes concurrently

### DIFF
--- a/Sources/Command/FileHandle+Extras.swift
+++ b/Sources/Command/FileHandle+Extras.swift
@@ -12,7 +12,7 @@ extension FileHandle {
                     continuation.yield(data)
                 }
             }
-            
+
             continuation.onTermination = { @Sendable _ in
                 self.readabilityHandler = nil
             }

--- a/Sources/Command/FileHandle+Extras.swift
+++ b/Sources/Command/FileHandle+Extras.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension FileHandle {
+    func byteStream() -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { continuation in
+            self.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    continuation.finish()
+                    handle.readabilityHandler = nil
+                } else {
+                    continuation.yield(data)
+                }
+            }
+            
+            continuation.onTermination = { @Sendable _ in
+                self.readabilityHandler = nil
+            }
+        }
+    }
+}

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -1,9 +1,9 @@
 import Mockable
-import XCTest
+import Testing
 @testable import Command
 
-final class CommandRunnerRaceTests: XCTestCase {
-    func test_runsManyConcurrent_successful() async throws {
+struct CommandRunnerRaceTests {
+    @Test func runsManyConcurrent_successfully() async throws {
         let commandRunner = CommandRunner()
 
         try await withThrowingTaskGroup(of: String.self) { group in
@@ -16,7 +16,7 @@ final class CommandRunnerRaceTests: XCTestCase {
             }
 
             for try await result in group {
-                XCTAssertEqual(result, "test\n")
+                #expect(result == "test\n")
             }
         }
     }

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -1,0 +1,23 @@
+import Mockable
+import XCTest
+@testable import Command
+
+final class CommandRunnerRaceTests: XCTestCase {
+    func test_runsManyConcurrent_successful() async throws {
+        let commandRunner = CommandRunner()
+
+        try await withThrowingTaskGroup(of: String.self) { group in    
+            for _ in 0..<1000 {
+                group.addTask {
+                    return try await commandRunner
+                        .run(arguments: ["echo", "test"])
+                        .reduce("") { $0 + ($1.string() ?? "") }
+                }
+            }
+
+            for try await result in group {
+                XCTAssertEqual(result, "test\n")
+            }
+        }
+    }
+}

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -6,10 +6,10 @@ final class CommandRunnerRaceTests: XCTestCase {
     func test_runsManyConcurrent_successful() async throws {
         let commandRunner = CommandRunner()
 
-        try await withThrowingTaskGroup(of: String.self) { group in    
-            for _ in 0..<1000 {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            for _ in 0 ..< 1000 {
                 group.addTask {
-                    return try await commandRunner
+                    try await commandRunner
                         .run(arguments: ["echo", "test"])
                         .reduce("") { $0 + ($1.string() ?? "") }
                 }


### PR DESCRIPTION
This PR is an attempt at fixing #160. A test is included which attempts to exercise this case. It typically fails when running before the fix, and appears to pass every time after the fix.

I realise this is a bit of a departure on the code, very open to feedback on this, although I'd ask that you give any non-style changes a go locally, as this took a lot of trial and error to get to and lots of changes that one might expect would work, actually won't.

During development of this I found some other issues where similar things can happen (reading from closed file handles) in the `lookupExecutable` call, as this isn't as strict as the main command running. I'll attempt to tackle that separately, and haven't managed to reproduce that in a test yet.