### PR TITLE
fix: release note generation

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -18,3 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           commitTitleMatch: "false"
+          ignoreCommits: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version to release'
+        description: "The version to release"
         type: string
 
 permissions:
@@ -19,7 +19,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     timeout-minutes: 15
     if: "!startsWith(github.event.head_commit.message, '[Release]')"
     steps:
@@ -36,34 +36,25 @@ jobs:
           bumped_output=$(git cliff --bump)
           echo "Bumped output:"
           echo "${bumped_output}"
-  
+
           # Read the content of CHANGELOG.md
           changelog_content=$(cat CHANGELOG.md)
           echo "CHANGELOG.md content:"
           echo "${changelog_content}"
-  
+
           # Compare the outputs and set the result
           if [ "${bumped_output}" = "${changelog_content}" ]; then
             echo "should-release=false" >> $GITHUB_ENV
           else
             echo "should-release=true" >> $GITHUB_ENV
           fi
-      
+
       - name: Get next version
         id: next-version
         if: env.should-release == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "NEXT_VERSION=$(git cliff --bumped-version)" >> "$GITHUB_OUTPUT"
-      - name: Get release notes
-        id: release-notes
-        if: env.should-release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
-          git cliff --unreleased >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Update CHANGELOG.md
         if: env.should-release == 'true'
         env:
@@ -74,10 +65,19 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         if: env.should-release == 'true'
         with:
-          commit_options: '--allow-empty'
+          commit_options: "--allow-empty"
           tagging_message: ${{ steps.next-version.outputs.NEXT_VERSION }}
           skip_dirty_check: true
           commit_message: "[Release] Command ${{ steps.next-version.outputs.NEXT_VERSION }}"
+      - name: Get release notes
+        id: release-notes
+        if: env.should-release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
+          git cliff --latest >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         if: env.should-release == 'true'


### PR DESCRIPTION
I noticed our release notes contain an `[Unrelease]` section. It turns out there's a bug in our release automation that causes that section to be present. This PR fixes it by first updating the CHANGELOG, and then using `git cliff` to get the latest version.