### PR TITLE
feat: add non-throwing version of concatenatedString

### DIFF
--- a/Sources/Command/AsyncThrowingStream+Extras.swift
+++ b/Sources/Command/AsyncThrowingStream+Extras.swift
@@ -15,6 +15,28 @@ extension AsyncThrowingStream where Element == CommandEvent {
         }
     }
 
+    /// Concatenates the stdout and stderr events encoded as strings using the provided encoding.
+    /// - Parameter encoding: The encoding to use. When absent, it defaults to UTF-8.
+    /// - Returns: The result of concatenating all the strings, and the error if one occurred.
+    public func nonThrowingConcatenatedString(
+      including: Set<CommandEvent.Pipeline> = [.standardOutput, .standardError],
+      encoding: String.Encoding = .utf8
+    ) async -> (output: String, error: Error?) {
+      var output = ""
+
+      do {
+        for try await event in self {
+          if including.contains(event.pipeline),
+             let stringValue = event.string(encoding: encoding) {
+            output.append(stringValue)
+          }
+        }
+        return (output, nil)
+      } catch {
+        return (output, error)
+      }
+    }
+
     /// Returns a new AsyncThrowingStream that pipes the standard output and standard error through the process' standard output
     /// and error.
     public func pipedStream() -> AsyncThrowingStream<Element, Error> {


### PR DESCRIPTION
Add a non-throwing version for AsyncThrowingStream's concatenatedString. This allows getting the stdout even when an error is thrown