### PR TITLE
fix: surface stderr and conform CommandError to LocalizedError

### DIFF
--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
-        swift: ["6.0"]
+        swift: ["6.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15, ubuntu-latest, windows-latest]
-        swift: ["6.0"]
+        swift: ["6.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -104,7 +104,7 @@ public enum CommandEvent: Sendable {
     }
 }
 
-public enum CommandError: Error, CustomStringConvertible, Sendable {
+public enum CommandError: Error, CustomStringConvertible, LocalizedError, Sendable {
     case terminated(Int32, stderr: String, command: [String])
     case signalled(Int32, command: [String])
     case executableNotFound(String)
@@ -114,11 +114,20 @@ public enum CommandError: Error, CustomStringConvertible, Sendable {
         switch self {
         case let .signalled(code, command):
             return "The command '\(command.joined(separator: " "))' terminated after receiving a signal with code \(code)"
-        case let .terminated(code, _, command):
-            return "The command '\(command.joined(separator: " "))' terminated with the code \(code)"
+        case let .terminated(code, stderr, command):
+            let trimmedStderr = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let base = "The command '\(command.joined(separator: " "))' terminated with the code \(code)"
+            if trimmedStderr.isEmpty {
+                return base
+            }
+            return "\(base):\n\(trimmedStderr)"
         case let .executableNotFound(name): return "Couldn't locate the executable '\(name)' in the environment."
         case .missingExecutableName: return "The executable name is missing."
         }
+    }
+
+    public var errorDescription: String? {
+        description
     }
 }
 

--- a/Tests/CommandTests/CommandRunnerTests.swift
+++ b/Tests/CommandTests/CommandRunnerTests.swift
@@ -83,9 +83,10 @@ import Testing
             let description = error.description
 
             // Then
-            #expect(description.contains("xcodebuild test-without-building -enumerate-tests"))
-            #expect(description.contains("code 70"))
-            #expect(description.contains("xcodebuild: error: No such scheme."))
+            #expect(
+                description ==
+                    "The command 'xcodebuild test-without-building -enumerate-tests' terminated with the code 70:\nxcodebuild: error: No such scheme."
+            )
         }
 
         @Test func commandError_terminated_descriptionOmitsEmptyStderr() {
@@ -100,9 +101,7 @@ import Testing
             let description = error.description
 
             // Then
-            #expect(!description.contains(":\n"))
-            #expect(description.contains("'echo hi'"))
-            #expect(description.contains("code 1"))
+            #expect(description == "The command 'echo hi' terminated with the code 1")
         }
 
         @Test func commandError_localizedDescriptionMatchesDescription() {
@@ -117,8 +116,7 @@ import Testing
             let localized = (error as any Error).localizedDescription
 
             // Then
-            #expect(localized == error.description)
-            #expect(localized.contains("boom"))
+            #expect(localized == "The command 'ls /missing' terminated with the code 2:\nboom")
         }
     }
 #endif

--- a/Tests/CommandTests/CommandRunnerTests.swift
+++ b/Tests/CommandTests/CommandRunnerTests.swift
@@ -70,5 +70,55 @@ import Testing
             // When & Then
             #expect(throws: (any Error).self, performing: { try commandRunner.lookupExecutable(firstArgument: nil) })
         }
+
+        @Test func commandError_terminated_descriptionIncludesStderr() {
+            // Given
+            let error = CommandError.terminated(
+                70,
+                stderr: "xcodebuild: error: No such scheme.",
+                command: ["xcodebuild", "test-without-building", "-enumerate-tests"]
+            )
+
+            // When
+            let description = error.description
+
+            // Then
+            #expect(description.contains("xcodebuild test-without-building -enumerate-tests"))
+            #expect(description.contains("code 70"))
+            #expect(description.contains("xcodebuild: error: No such scheme."))
+        }
+
+        @Test func commandError_terminated_descriptionOmitsEmptyStderr() {
+            // Given
+            let error = CommandError.terminated(
+                1,
+                stderr: "   \n",
+                command: ["echo", "hi"]
+            )
+
+            // When
+            let description = error.description
+
+            // Then
+            #expect(!description.contains(":\n"))
+            #expect(description.contains("'echo hi'"))
+            #expect(description.contains("code 1"))
+        }
+
+        @Test func commandError_localizedDescriptionMatchesDescription() {
+            // Given
+            let error = CommandError.terminated(
+                2,
+                stderr: "boom",
+                command: ["ls", "/missing"]
+            )
+
+            // When
+            let localized = (error as any Error).localizedDescription
+
+            // Then
+            #expect(localized == error.description)
+            #expect(localized.contains("boom"))
+        }
     }
 #endif


### PR DESCRIPTION
### Summary

When a `CommandError` thrown by `CommandRunner` reached a caller that inspected `error.localizedDescription`, Swift produced the unhelpful fallback:

```
The operation couldn't be completed. (Command.CommandError error 0.)
```

That happened because `CommandError` only conformed to `CustomStringConvertible`, not `LocalizedError`, so `localizedDescription` fell back to NSError's default formatter — discarding the exit code, command, and stderr that the runner had already collected.

On top of that, even `description` for `.terminated` dropped the stderr, so callers reaching for `String(describing:)` couldn't see what the underlying tool actually printed.

### Changes

- `CommandError` now conforms to `LocalizedError`. `errorDescription` returns the same string as `description`, so `error.localizedDescription` is finally useful.
- `.terminated`'s `description` now appends the trimmed stderr (when non-empty), so a failure surfaces as e.g.:

  ```
  The command 'xcodebuild test-without-building -enumerate-tests' terminated with the code 70:
  xcodebuild: error: No such scheme.
  ```

### How to test locally

```sh
swift test --replace-scm-with-registry --filter CommandRunnerTests
```

Three new tests cover the new behavior:
- `commandError_terminated_descriptionIncludesStderr`
- `commandError_terminated_descriptionOmitsEmptyStderr`
- `commandError_localizedDescriptionMatchesDescription`

### Impact

Every consumer of `tuist/Command` that previously logged `error.localizedDescription` on a thrown `CommandError` will now get an actionable message instead of the opaque NSError fallback. Real-world example: `tuist test --shard-granularity suite` was reporting `Test enumeration failed: <path>: The operation couldn't be completed. (Command.CommandError error 0.)` to users, hiding the actual `xcodebuild` stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)