### PR TITLE
fix: replace blocking waitUntilExit with async terminationHandler to prevent thread starvation

### DIFF
--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -216,8 +216,17 @@ public struct CommandRunner: CommandRunning, Sendable {
                         }
                     }
 
-                    try process.run()
-                    process.waitUntilExit()
+                    try await withCheckedThrowingContinuation { (processCompletion: CheckedContinuation<Void, any Error>) in
+                        process.terminationHandler = { _ in
+                            processCompletion.resume()
+                        }
+                        do {
+                            try process.run()
+                        } catch {
+                            process.terminationHandler = nil
+                            processCompletion.resume(throwing: error)
+                        }
+                    }
 
                     await stdoutTask.value
                     await stderrTask.value

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -23,5 +23,38 @@ import Testing
                 }
             #endif
         }
+
+        @Test func runsManyConcurrentCommandsWithLargeOutput_successfully() async throws {
+            #if os(macOS)
+                let commandRunner = CommandRunner()
+                let byteCount = 256 * 1024
+                let shellCommand = """
+                dd if=/dev/zero bs=1024 count=256 2>/dev/null
+                dd if=/dev/zero bs=1024 count=256 1>&2 2>/dev/null
+                """
+
+                try await withThrowingTaskGroup(of: (standardOutput: Int, standardError: Int).self) { group in
+                    for _ in 0 ..< 64 {
+                        group.addTask {
+                            try await commandRunner
+                                .run(arguments: ["/bin/sh", "-c", shellCommand])
+                                .reduce(into: (standardOutput: 0, standardError: 0)) { counts, event in
+                                    switch event {
+                                    case let .standardOutput(bytes):
+                                        counts.standardOutput += bytes.count
+                                    case let .standardError(bytes):
+                                        counts.standardError += bytes.count
+                                    }
+                                }
+                        }
+                    }
+
+                    for try await result in group {
+                        #expect(result.standardOutput == byteCount)
+                        #expect(result.standardError == byteCount)
+                    }
+                }
+            #endif
+        }
     }
 #endif


### PR DESCRIPTION
###  Summary

Replace `process.waitUntilExit()` with `process.terminationHandler` + `CheckedContinuation` to avoid blocking the cooperative thread pool

###   Problem

`CommandRunner.run()` executes inside a `Task.detached`, which runs on Swift's cooperative thread pool. The call to `process.waitUntilExit()` blocks that thread until the subprocess finishes. When multiple commands run concurrently (e.g., during manifest loading in a large monorepo), each blocked thread reduces pool capacity. Once all pool threads are occupied by `waitUntilExit()` calls, the `stdoutTask` and `stderrTask` pipe-reading tasks can never be scheduled. The subprocesses then fill their pipe buffers and block on write, while `waitUntilExit()` waits for processes that can never finish — a classic thread starvation deadlock.

This causes tuist generate and tuist test to hang indefinitely at "Loading and constructing the graph" in large repos.

###   Fix

Replace the blocking `waitUntilExit()` with an async-friendly `terminationHandler` that suspends the task via `CheckedContinuation`. This frees the pool thread while waiting for the process to exit, allowing pipe-draining tasks to be scheduled normally.