### PR TITLE
fix: propagate error instead of trapping when working directory cannot be resolved

### DIFF
--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -109,6 +109,7 @@ public enum CommandError: Error, CustomStringConvertible, LocalizedError, Sendab
     case signalled(Int32, command: [String])
     case executableNotFound(String)
     case missingExecutableName
+    case invalidWorkingDirectory(String)
 
     public var description: String {
         switch self {
@@ -123,6 +124,11 @@ public enum CommandError: Error, CustomStringConvertible, LocalizedError, Sendab
             return "\(base):\n\(trimmedStderr)"
         case let .executableNotFound(name): return "Couldn't locate the executable '\(name)' in the environment."
         case .missingExecutableName: return "The executable name is missing."
+        case let .invalidWorkingDirectory(path):
+            if path.isEmpty {
+                return "Couldn't resolve the current working directory: FileManager returned an empty path (getcwd likely failed)."
+            }
+            return "The resolved working directory '\(path)' is not a valid absolute path."
         }
     }
 
@@ -151,8 +157,15 @@ public struct CommandRunner: CommandRunning, Sendable {
                     // Get the working directory if not passed.
                     var workingDirectory = workingDirectory
                     if workingDirectory == nil {
-                        // swiftlint:disable:next force_try
-                        workingDirectory = try! .init(validating: FileManager.default.currentDirectoryPath)
+                        let currentDirectoryPath = FileManager.default.currentDirectoryPath
+                        guard !currentDirectoryPath.isEmpty else {
+                            throw CommandError.invalidWorkingDirectory("")
+                        }
+                        do {
+                            workingDirectory = try .init(validating: currentDirectoryPath)
+                        } catch {
+                            throw CommandError.invalidWorkingDirectory(currentDirectoryPath)
+                        }
                     }
 
                     let collectedStdErr: ThreadSafe<String> = ThreadSafe("")

--- a/Tests/CommandTests/CommandRunnerTests.swift
+++ b/Tests/CommandTests/CommandRunnerTests.swift
@@ -118,5 +118,30 @@ import Testing
             // Then
             #expect(localized == "The command 'ls /missing' terminated with the code 2:\nboom")
         }
+
+        @Test func commandError_invalidWorkingDirectory_empty_descriptionMentionsGetcwd() {
+            // Given
+            let error = CommandError.invalidWorkingDirectory("")
+
+            // When
+            let description = error.description
+
+            // Then
+            #expect(
+                description ==
+                    "Couldn't resolve the current working directory: FileManager returned an empty path (getcwd likely failed)."
+            )
+        }
+
+        @Test func commandError_invalidWorkingDirectory_nonEmpty_includesPath() {
+            // Given
+            let error = CommandError.invalidWorkingDirectory("relative/path")
+
+            // When
+            let description = error.description
+
+            // Then
+            #expect(description == "The resolved working directory 'relative/path' is not a valid absolute path.")
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

`CommandRunner.run` defaulted to `FileManager.default.currentDirectoryPath` when no working directory was provided, then validated it via `try!`. When `getcwd(3)` fails (cwd deleted, unsearchable, buffer too small, fd exhaustion), Foundation returns an empty string and `AbsolutePath(validating: "")` throws — the `try!` turned that into a `Trace/BPT trap: 5`, aborting the process before any error unwinds. Callers saw no Swift error and no usable stack trace.

This replaces the `try!` with proper validation that throws a new `CommandError.invalidWorkingDirectory` through the `AsyncThrowingStream` continuation. The caller-visible code path now surfaces a regular Swift error containing the offending string, so the originating call site shows up in the awaiting code instead of as a process crash.

### Why this matters

A Tuist user reported a `Trace/BPT trap: 5` during `tuist generate` with three identical `Command/CommandRunner.swift:155: Fatal error: 'try!' expression unexpectedly raised an error: invalid absolute path ''` lines — one per concurrent `Task.detached`. The trap left no stack, so the call site could not be identified from the report. After this change, the same condition surfaces as a normal Swift error at the call site that awaits the stream.

## Test plan

- [x] `swift test --replace-scm-with-registry` passes (14 tests, 3 suites)
- [x] New `commandError_invalidWorkingDirectory_*` tests cover both the empty-path and non-absolute-path description branches