### PR TITLE
fix: don't require getcwd to succeed when launching subprocesses

### DIFF
--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -154,17 +154,14 @@ public struct CommandRunner: CommandRunning, Sendable {
             Task.detached {
                 do {
                     let loggerMetadata: Logger.Metadata = ["command": .string(arguments.joined(separator: " "))]
-                    // Get the working directory if not passed.
+                    // Resolve the working directory if not passed. `getcwd` can transiently
+                    // return an empty path under concurrent process launches, so fall back to
+                    // letting the child inherit the process working directory instead of failing.
                     var workingDirectory = workingDirectory
                     if workingDirectory == nil {
                         let currentDirectoryPath = FileManager.default.currentDirectoryPath
-                        guard !currentDirectoryPath.isEmpty else {
-                            throw CommandError.invalidWorkingDirectory("")
-                        }
-                        do {
-                            workingDirectory = try .init(validating: currentDirectoryPath)
-                        } catch {
-                            throw CommandError.invalidWorkingDirectory(currentDirectoryPath)
+                        if !currentDirectoryPath.isEmpty {
+                            workingDirectory = try? .init(validating: currentDirectoryPath)
                         }
                     }
 
@@ -202,7 +199,9 @@ public struct CommandRunner: CommandRunning, Sendable {
                         }
                     }
 
-                    process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory!.pathString)
+                    if let workingDirectory {
+                        process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory.pathString)
+                    }
                     process.standardOutput = stdoutPipe
                     process.standardError = stderrPipe
                     process.standardInput = FileHandle.standardInput
@@ -300,7 +299,9 @@ public struct CommandRunner: CommandRunning, Sendable {
         process.executableURL = URL(fileURLWithPath: command)
         process.arguments = arguments
         process.environment = ProcessInfo.processInfo.environment
-        process.currentDirectoryURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        // `which`/`where` resolves the executable from `PATH`, not the working directory, so
+        // we don't set `currentDirectoryURL`. Reading `getcwd` here crashed `NSTask` when it
+        // transiently returned an empty path under concurrent process launches.
 
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -299,9 +299,6 @@ public struct CommandRunner: CommandRunning, Sendable {
         process.executableURL = URL(fileURLWithPath: command)
         process.arguments = arguments
         process.environment = ProcessInfo.processInfo.environment
-        // `which`/`where` resolves the executable from `PATH`, not the working directory, so
-        // we don't set `currentDirectoryURL`. Reading `getcwd` here crashed `NSTask` when it
-        // transiently returned an empty path under concurrent process launches.
 
         let pipe = Pipe()
         process.standardOutput = pipe


### PR DESCRIPTION
## What changed

Make `CommandRunner` tolerant of `getcwd` returning an empty path:

- In `run()`, when no `workingDirectory` is passed and `FileManager.default.currentDirectoryPath` is empty, leave `currentDirectoryURL` unset so the child inherits the process working directory, instead of throwing `invalidWorkingDirectory("")`.
- In `lookupExecutable()`, stop setting the `which`/`where` helper's `currentDirectoryURL` from `getcwd`. That lookup resolves via `PATH` and never needs a working directory; reading `getcwd` there crashed `NSTask` with "non-file URL argument" on an empty path.

## Why

Reported downstream in Tuist: `tuist graph` (and other commands) crash on CI with either:

```
Couldn't resolve the current working directory: FileManager returned an empty path (getcwd likely failed).
```

or, for bare-name executables (git, swift, xcodebuild, …):

```
*** -[NSConcreteTask setCurrentDirectoryURL:]: non-file URL argument
Command.CommandRunner.lookupExecutable(firstArgument:)
```

A consumer's version bisection isolated the regression to the `Command` bump 0.14.1 → 0.14.4. The only relevant change in that range is #249, which replaced the blocking `waitUntilExit()` with an async `terminationHandler` + `CheckedContinuation`.

## Root cause

#249 is correct (it fixes thread starvation), but it changes the concurrency of subprocess launches. Previously each `Task.detached` held a cooperative thread for the subprocess's entire lifetime, so launches were effectively serialized by the small cooperative pool. After #249 they suspend while waiting and run concurrently. Under that concurrency, Foundation's per-launch working-directory handling on macOS races, and `getcwd` (`FileManager.currentDirectoryPath`) transiently returns an empty string — even though the process working directory is valid (the same workload on 0.14.1 never hits it).

`CommandRunner` assumed `getcwd` always succeeds and fed the empty result straight into `Process`, producing the throw/crash. This change removes that assumption: when the cwd can't be resolved we inherit the process working directory (the pre-async behavior), and the executable lookup no longer touches `getcwd` at all.

## Validation

`swift build` and `swift test` pass locally (14 tests across 3 suites, including the concurrency race suite).

### End-to-end reproduction and verification

Because the crash can't be triggered reliably by the concurrency race on demand, we forced the exact failing condition deterministically — an empty `getcwd` while `$PWD` still points to a valid directory (the shape a CI step produces when it deletes and recreates the working directory).

**1. Direct `Command`-layer repro (the `NSTask` crash).** A ~20-line executable depending on `Command` enters a temp dir, deletes it (so `getcwd` returns `""`), then calls `run(arguments: ["git", "--version"], workingDirectory: <abs path>)` — a bare-name executable with an explicit working directory, i.e. the path through `lookupExecutable`.

- Against `Command` **before** this change:
  ```
  getcwd now: ''
  *** Terminating app due to uncaught exception 'NSInvalidArgumentException',
      reason: '*** -[NSConcreteTask setCurrentDirectoryURL:]: non-file URL argument'
      Command.CommandRunner.lookupExecutable(firstArgument:)
      Command.CommandRunner.run(arguments:environment:workingDirectory:)
  ```
  (identical stack to the downstream crash report)
- Against `Command` **with** this change:
  ```
  getcwd now: ''
  git version 2.43.0
  RESULT: completed without crashing
  ```

**2. Full e2e through the Tuist binary on a real example.** Using Tuist's `examples/xcode/generated_app_with_alamofire` fixture (it has an SPM dependency, so `tuist graph` shells out to a bare-name `swift`), with the working directory deleted+recreated before running `tuist graph -f legacyJSON --no-open`:

- Released **tuist 4.195.11** (links `Command` 0.14.5):
  ```
  getcwd(/bin/pwd): pwd: .: No such file or directory
  PWD=.../proj exists? yes
  ✖ Error
    Couldn't resolve the current working directory: FileManager returned an empty path (getcwd likely failed).
  ```
- A local Tuist build with this `Command` change compiled in, same example, same condition:
  ```
  getcwd(/bin/pwd): pwd: .: No such file or directory
  PWD=.../proj exists? yes
  ✔ Success
    Graph exported to .../proj/graph.json
  ```

Same example and same empty-`getcwd` condition: the released binary fails, the patched binary succeeds.
