### PR TITLE
fix: bound concurrent subprocess launches to avoid fd exhaustion

### DIFF
--- a/Sources/Command/AsyncResourceLimiter.swift
+++ b/Sources/Command/AsyncResourceLimiter.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+actor AsyncResourceLimiter {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private let limitProvider: @Sendable () -> Int
+    private var limit: Int
+    private var activePermits = 0
+    private var waiters: [Waiter] = []
+
+    init(limit: Int) {
+        precondition(limit > 0, "AsyncResourceLimiter limit must be greater than zero.")
+        self.init(limitProvider: { limit })
+    }
+
+    init(limitProvider: @escaping @Sendable () -> Int) {
+        let limit = limitProvider()
+        precondition(limit > 0, "AsyncResourceLimiter limit must be greater than zero.")
+        self.limitProvider = limitProvider
+        self.limit = limit
+    }
+
+    func withPermit<T>(_ operation: @Sendable () async throws -> T) async throws -> T {
+        try await acquire()
+
+        do {
+            try Task.checkCancellation()
+            let value = try await operation()
+            release()
+            return value
+        } catch {
+            release()
+            throw error
+        }
+    }
+
+    private func acquire() async throws {
+        try Task.checkCancellation()
+        refreshLimit()
+
+        if activePermits < limit, waiters.isEmpty {
+            activePermits += 1
+            return
+        }
+
+        let waiterID = UUID()
+        let wasGrantedPermit = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                waiters.append(Waiter(id: waiterID, continuation: continuation))
+                grantAvailablePermits()
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: waiterID) }
+        }
+
+        guard wasGrantedPermit else {
+            throw CancellationError()
+        }
+    }
+
+    private func release() {
+        refreshLimit()
+        activePermits -= 1
+        precondition(activePermits >= 0, "AsyncResourceLimiter released more permits than it acquired.")
+        grantAvailablePermits()
+    }
+
+    private func refreshLimit() {
+        let refreshedLimit = limitProvider()
+        precondition(refreshedLimit > 0, "AsyncResourceLimiter limit must be greater than zero.")
+        limit = refreshedLimit
+    }
+
+    private func grantAvailablePermits() {
+        while activePermits < limit, !waiters.isEmpty {
+            let waiter = waiters.removeFirst()
+            activePermits += 1
+            waiter.continuation.resume(returning: true)
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+        refreshLimit()
+        grantAvailablePermits()
+    }
+}

--- a/Sources/Command/AsyncResourceLimiter.swift
+++ b/Sources/Command/AsyncResourceLimiter.swift
@@ -23,7 +23,7 @@ actor AsyncResourceLimiter {
         self.limit = limit
     }
 
-    func withPermit<T>(_ operation: @Sendable () async throws -> T) async throws -> T {
+    func withPermit<T: Sendable>(_ operation: @Sendable () async throws -> T) async throws -> T {
         try await acquire()
 
         do {

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -6,6 +6,12 @@ import Logging
 #endif
 import Path
 
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
 /**
  `CommandRunning` is a protocol that declares the interface to run system processes.
  The main implementation of the protocol is `CommandRunner`.
@@ -144,6 +150,43 @@ public struct CommandRunner: CommandRunning, Sendable {
         self.logger = logger
     }
 
+    /// File descriptors kept in reserve for stdio and other process-wide handles.
+    private static let reservedFileDescriptors = 32
+    /// Approximate number of file descriptors a running subprocess holds (two pipes, plus the
+    /// transient pipe used to locate the executable).
+    private static let fileDescriptorsPerProcess = 6
+    /// Upper bound on concurrent subprocesses, regardless of how high the file-descriptor limit is.
+    private static let maximumConcurrentProcesses = 256
+    /// Used when the file-descriptor limit can't be determined.
+    private static let fallbackMaximumConcurrentProcesses = 16
+
+    /// Bounds the number of concurrently-running subprocesses so the pipe file descriptors they
+    /// hold can't exhaust the process's file-descriptor table. The limit is derived from the
+    /// current soft `RLIMIT_NOFILE`, so it adapts if the limit is raised at startup.
+    private static let processLimiter = AsyncResourceLimiter(
+        limitProvider: { systemMaximumConcurrentProcesses() }
+    )
+
+    private static func systemMaximumConcurrentProcesses() -> Int {
+        #if os(Windows)
+            return fallbackMaximumConcurrentProcesses
+        #else
+            var resourceLimit = rlimit()
+            #if canImport(Glibc)
+                let openFilesResource = Int32(RLIMIT_NOFILE.rawValue)
+            #else
+                let openFilesResource = RLIMIT_NOFILE
+            #endif
+            guard getrlimit(openFilesResource, &resourceLimit) == 0 else {
+                return fallbackMaximumConcurrentProcesses
+            }
+            let softLimit = Int(clamping: resourceLimit.rlim_cur)
+            let descriptorsAvailable = max(1, softLimit - reservedFileDescriptors)
+            let proportionalLimit = max(1, descriptorsAvailable / fileDescriptorsPerProcess)
+            return min(maximumConcurrentProcesses, proportionalLimit)
+        #endif
+    }
+
     // swiftlint:disable:next function_body_length
     public func run(
         arguments: [String],
@@ -153,114 +196,116 @@ public struct CommandRunner: CommandRunning, Sendable {
         AsyncThrowingStream(CommandEvent.self, bufferingPolicy: .unbounded) { continuation in
             Task.detached {
                 do {
-                    let loggerMetadata: Logger.Metadata = ["command": .string(arguments.joined(separator: " "))]
-                    // Resolve the working directory if not passed. `getcwd` can transiently
-                    // return an empty path under concurrent process launches, so fall back to
-                    // letting the child inherit the process working directory instead of failing.
-                    var workingDirectory = workingDirectory
-                    if workingDirectory == nil {
-                        let currentDirectoryPath = FileManager.default.currentDirectoryPath
-                        if !currentDirectoryPath.isEmpty {
-                            workingDirectory = try? .init(validating: currentDirectoryPath)
+                    try await Self.processLimiter.withPermit {
+                        let loggerMetadata: Logger.Metadata = ["command": .string(arguments.joined(separator: " "))]
+                        // Resolve the working directory if not passed. `getcwd` can transiently
+                        // return an empty path under concurrent process launches, so fall back to
+                        // letting the child inherit the process working directory instead of failing.
+                        var workingDirectory = workingDirectory
+                        if workingDirectory == nil {
+                            let currentDirectoryPath = FileManager.default.currentDirectoryPath
+                            if !currentDirectoryPath.isEmpty {
+                                workingDirectory = try? .init(validating: currentDirectoryPath)
+                            }
                         }
-                    }
 
-                    let collectedStdErr: ThreadSafe<String> = ThreadSafe("")
+                        let collectedStdErr: ThreadSafe<String> = ThreadSafe("")
 
-                    // Process
-                    let process = Process()
-                    let stdoutPipe = Pipe()
-                    let stderrPipe = Pipe()
+                        // Process
+                        let process = Process()
+                        let stdoutPipe = Pipe()
+                        let stderrPipe = Pipe()
 
-                    let stdoutTask = Task {
-                        do {
-                            for try await data in stdoutPipe.fileHandleForReading.byteStream() {
-                                continuation.yield(.standardOutput([UInt8](data)))
-                                if let output = String(data: data, encoding: .utf8) {
-                                    logger?.debug("\(output)", metadata: loggerMetadata)
+                        let stdoutTask = Task {
+                            do {
+                                for try await data in stdoutPipe.fileHandleForReading.byteStream() {
+                                    continuation.yield(.standardOutput([UInt8](data)))
+                                    if let output = String(data: data, encoding: .utf8) {
+                                        logger?.debug("\(output)", metadata: loggerMetadata)
+                                    }
                                 }
+                            } catch {
+                                logger?.error("Error reading stdout: \(error)", metadata: loggerMetadata)
                             }
-                        } catch {
-                            logger?.error("Error reading stdout: \(error)", metadata: loggerMetadata)
                         }
-                    }
 
-                    let stderrTask = Task {
-                        do {
-                            for try await data in stderrPipe.fileHandleForReading.byteStream() {
-                                continuation.yield(.standardError([UInt8](data)))
-                                if let output = String(data: data, encoding: .utf8) {
-                                    collectedStdErr.mutate { $0.append(output) }
-                                    logger?.error("\(output)", metadata: loggerMetadata)
+                        let stderrTask = Task {
+                            do {
+                                for try await data in stderrPipe.fileHandleForReading.byteStream() {
+                                    continuation.yield(.standardError([UInt8](data)))
+                                    if let output = String(data: data, encoding: .utf8) {
+                                        collectedStdErr.mutate { $0.append(output) }
+                                        logger?.error("\(output)", metadata: loggerMetadata)
+                                    }
                                 }
+                            } catch {
+                                logger?.error("Error reading stderr: \(error)", metadata: loggerMetadata)
                             }
-                        } catch {
-                            logger?.error("Error reading stderr: \(error)", metadata: loggerMetadata)
                         }
-                    }
 
-                    if let workingDirectory {
-                        process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory.pathString)
-                    }
-                    process.standardOutput = stdoutPipe
-                    process.standardError = stderrPipe
-                    process.standardInput = FileHandle.standardInput
-                    process.environment = environment
+                        if let workingDirectory {
+                            process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory.pathString)
+                        }
+                        process.standardOutput = stdoutPipe
+                        process.standardError = stderrPipe
+                        process.standardInput = FileHandle.standardInput
+                        process.environment = environment
 
-                    let processArguments = Array(arguments.dropFirst())
-                    process.arguments = processArguments
+                        let processArguments = Array(arguments.dropFirst())
+                        process.arguments = processArguments
 
-                    let executable = try lookupExecutable(firstArgument: arguments.first)
-                    process.executableURL = executable
+                        let executable = try lookupExecutable(firstArgument: arguments.first)
+                        process.executableURL = executable
 
-                    logger?.debug("Running sub-process", metadata: loggerMetadata)
+                        logger?.debug("Running sub-process", metadata: loggerMetadata)
 
-                    let threadSafeProcess = ThreadSafe(process)
+                        let threadSafeProcess = ThreadSafe(process)
 
-                    continuation.onTermination = { termination in
-                        switch termination {
-                        case .cancelled:
-                            if threadSafeProcess.value.isRunning {
-                                threadSafeProcess.value.terminate()
+                        continuation.onTermination = { termination in
+                            switch termination {
+                            case .cancelled:
+                                if threadSafeProcess.value.isRunning {
+                                    threadSafeProcess.value.terminate()
+                                }
+                            default:
+                                break
                             }
-                        default:
+                        }
+
+                        try await withCheckedThrowingContinuation { (processCompletion: CheckedContinuation<Void, any Error>) in
+                            process.terminationHandler = { _ in
+                                processCompletion.resume()
+                            }
+                            do {
+                                try process.run()
+                            } catch {
+                                process.terminationHandler = nil
+                                processCompletion.resume(throwing: error)
+                            }
+                        }
+
+                        await stdoutTask.value
+                        await stderrTask.value
+
+                        try? stdoutPipe.fileHandleForReading.close()
+                        try? stderrPipe.fileHandleForReading.close()
+
+                        switch process.terminationReason {
+                        case .exit:
+                            if process.terminationStatus != 0 {
+                                throw CommandError.terminated(
+                                    process.terminationStatus,
+                                    stderr: collectedStdErr.value,
+                                    command: arguments
+                                )
+                            }
+                        case .uncaughtSignal:
+                            if process.terminationStatus != 0 {
+                                throw CommandError.signalled(process.terminationStatus, command: arguments)
+                            }
+                        @unknown default:
                             break
                         }
-                    }
-
-                    try await withCheckedThrowingContinuation { (processCompletion: CheckedContinuation<Void, any Error>) in
-                        process.terminationHandler = { _ in
-                            processCompletion.resume()
-                        }
-                        do {
-                            try process.run()
-                        } catch {
-                            process.terminationHandler = nil
-                            processCompletion.resume(throwing: error)
-                        }
-                    }
-
-                    await stdoutTask.value
-                    await stderrTask.value
-
-                    try? stdoutPipe.fileHandleForReading.close()
-                    try? stderrPipe.fileHandleForReading.close()
-
-                    switch process.terminationReason {
-                    case .exit:
-                        if process.terminationStatus != 0 {
-                            throw CommandError.terminated(
-                                process.terminationStatus,
-                                stderr: collectedStdErr.value,
-                                command: arguments
-                            )
-                        }
-                    case .uncaughtSignal:
-                        if process.terminationStatus != 0 {
-                            throw CommandError.signalled(process.terminationStatus, command: arguments)
-                        }
-                    @unknown default:
-                        break
                     }
                     continuation.finish()
                 } catch {

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -12,6 +12,18 @@ import Path
     import Glibc
 #endif
 
+/// Controls how a subprocess's standard output and error are handled.
+public enum OutputRedirection: Sendable {
+    /// Captures standard output and error through pipes and emits them as `CommandEvent`s.
+    case capture
+    /// Discards standard output and error by redirecting them to the null device. No pipes are
+    /// created, so the command holds no extra file descriptors and emits no events.
+    case discard
+    /// Lets the subprocess inherit the parent process's standard output and error. No pipes are
+    /// created and no events are emitted.
+    case inherit
+}
+
 /**
  `CommandRunning` is a protocol that declares the interface to run system processes.
  The main implementation of the protocol is `CommandRunner`.
@@ -32,6 +44,21 @@ public protocol CommandRunning: Sendable {
         arguments: [String],
         environment: [String: String],
         workingDirectory: Path.AbsolutePath?
+    ) -> AsyncThrowingStream<CommandEvent, any Error>
+
+    /// Runs a command in the system, controlling how its output is handled.
+    /// - Parameters:
+    ///   - arguments: The command arguments where the first argument represents the executable.
+    ///   - environment: The environment variables that will be passed to the process running the command.
+    ///   - workingDirectory: The directory from where the command will be executed.
+    ///   - output: How the subprocess's standard output and error are handled. Use ``OutputRedirection/discard`` or
+    /// ``OutputRedirection/inherit`` to avoid allocating output pipes when the output isn't needed.
+    /// - Returns: An async throwing stream to subscribe to the emitted events and completion of the underlying process.
+    func run(
+        arguments: [String],
+        environment: [String: String],
+        workingDirectory: Path.AbsolutePath?,
+        output: OutputRedirection
     ) -> AsyncThrowingStream<CommandEvent, any Error>
 }
 
@@ -197,11 +224,20 @@ public struct CommandRunner: CommandRunning, Sendable {
         #endif
     }
 
-    // swiftlint:disable:next function_body_length
     public func run(
         arguments: [String],
         environment: [String: String] = ProcessInfo.processInfo.environment,
         workingDirectory: Path.AbsolutePath? = nil
+    ) -> AsyncThrowingStream<CommandEvent, any Error> {
+        run(arguments: arguments, environment: environment, workingDirectory: workingDirectory, output: .capture)
+    }
+
+    // swiftlint:disable:next function_body_length
+    public func run(
+        arguments: [String],
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        workingDirectory: Path.AbsolutePath? = nil,
+        output: OutputRedirection = .capture
     ) -> AsyncThrowingStream<CommandEvent, any Error> {
         AsyncThrowingStream(CommandEvent.self, bufferingPolicy: .unbounded) { continuation in
             let runningProcess = ThreadSafe<Process?>(nil)
@@ -225,41 +261,64 @@ public struct CommandRunner: CommandRunning, Sendable {
 
                         // Process
                         let process = Process()
-                        let stdoutPipe = Pipe()
-                        let stderrPipe = Pipe()
 
-                        let stdoutTask = Task {
-                            do {
-                                for try await data in stdoutPipe.fileHandleForReading.byteStream() {
-                                    continuation.yield(.standardOutput([UInt8](data)))
-                                    if let output = String(data: data, encoding: .utf8) {
-                                        logger?.debug("\(output)", metadata: loggerMetadata)
-                                    }
-                                }
-                            } catch {
-                                logger?.error("Error reading stdout: \(error)", metadata: loggerMetadata)
-                            }
-                        }
+                        // Only allocate output pipes when the caller wants to capture output.
+                        // Discarding or inheriting avoids holding any extra file descriptors.
+                        let stdoutPipe: Pipe?
+                        let stderrPipe: Pipe?
+                        let stdoutTask: Task<Void, Never>?
+                        let stderrTask: Task<Void, Never>?
 
-                        let stderrTask = Task {
-                            do {
-                                for try await data in stderrPipe.fileHandleForReading.byteStream() {
-                                    continuation.yield(.standardError([UInt8](data)))
-                                    if let output = String(data: data, encoding: .utf8) {
-                                        collectedStdErr.mutate { $0.append(output) }
-                                        logger?.error("\(output)", metadata: loggerMetadata)
+                        switch output {
+                        case .capture:
+                            let outPipe = Pipe()
+                            let errPipe = Pipe()
+                            stdoutPipe = outPipe
+                            stderrPipe = errPipe
+                            process.standardOutput = outPipe
+                            process.standardError = errPipe
+                            stdoutTask = Task {
+                                do {
+                                    for try await data in outPipe.fileHandleForReading.byteStream() {
+                                        continuation.yield(.standardOutput([UInt8](data)))
+                                        if let output = String(data: data, encoding: .utf8) {
+                                            logger?.debug("\(output)", metadata: loggerMetadata)
+                                        }
                                     }
+                                } catch {
+                                    logger?.error("Error reading stdout: \(error)", metadata: loggerMetadata)
                                 }
-                            } catch {
-                                logger?.error("Error reading stderr: \(error)", metadata: loggerMetadata)
                             }
+                            stderrTask = Task {
+                                do {
+                                    for try await data in errPipe.fileHandleForReading.byteStream() {
+                                        continuation.yield(.standardError([UInt8](data)))
+                                        if let output = String(data: data, encoding: .utf8) {
+                                            collectedStdErr.mutate { $0.append(output) }
+                                            logger?.error("\(output)", metadata: loggerMetadata)
+                                        }
+                                    }
+                                } catch {
+                                    logger?.error("Error reading stderr: \(error)", metadata: loggerMetadata)
+                                }
+                            }
+                        case .discard:
+                            stdoutPipe = nil
+                            stderrPipe = nil
+                            stdoutTask = nil
+                            stderrTask = nil
+                            process.standardOutput = FileHandle.nullDevice
+                            process.standardError = FileHandle.nullDevice
+                        case .inherit:
+                            stdoutPipe = nil
+                            stderrPipe = nil
+                            stdoutTask = nil
+                            stderrTask = nil
                         }
 
                         if let workingDirectory {
                             process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory.pathString)
                         }
-                        process.standardOutput = stdoutPipe
-                        process.standardError = stderrPipe
                         process.standardInput = FileHandle.standardInput
                         process.environment = environment
 
@@ -292,11 +351,11 @@ public struct CommandRunner: CommandRunning, Sendable {
                             }
                         }
 
-                        await stdoutTask.value
-                        await stderrTask.value
+                        await stdoutTask?.value
+                        await stderrTask?.value
 
-                        try? stdoutPipe.fileHandleForReading.close()
-                        try? stderrPipe.fileHandleForReading.close()
+                        try? stdoutPipe?.fileHandleForReading.close()
+                        try? stderrPipe?.fileHandleForReading.close()
 
                         switch process.terminationReason {
                         case .exit:

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -12,18 +12,6 @@ import Path
     import Glibc
 #endif
 
-/// Controls how a subprocess's standard output and error are handled.
-public enum OutputRedirection: Sendable {
-    /// Captures standard output and error through pipes and emits them as `CommandEvent`s.
-    case capture
-    /// Discards standard output and error by redirecting them to the null device. No pipes are
-    /// created, so the command holds no extra file descriptors and emits no events.
-    case discard
-    /// Lets the subprocess inherit the parent process's standard output and error. No pipes are
-    /// created and no events are emitted.
-    case inherit
-}
-
 /**
  `CommandRunning` is a protocol that declares the interface to run system processes.
  The main implementation of the protocol is `CommandRunner`.
@@ -44,21 +32,6 @@ public protocol CommandRunning: Sendable {
         arguments: [String],
         environment: [String: String],
         workingDirectory: Path.AbsolutePath?
-    ) -> AsyncThrowingStream<CommandEvent, any Error>
-
-    /// Runs a command in the system, controlling how its output is handled.
-    /// - Parameters:
-    ///   - arguments: The command arguments where the first argument represents the executable.
-    ///   - environment: The environment variables that will be passed to the process running the command.
-    ///   - workingDirectory: The directory from where the command will be executed.
-    ///   - output: How the subprocess's standard output and error are handled. Use ``OutputRedirection/discard`` or
-    /// ``OutputRedirection/inherit`` to avoid allocating output pipes when the output isn't needed.
-    /// - Returns: An async throwing stream to subscribe to the emitted events and completion of the underlying process.
-    func run(
-        arguments: [String],
-        environment: [String: String],
-        workingDirectory: Path.AbsolutePath?,
-        output: OutputRedirection
     ) -> AsyncThrowingStream<CommandEvent, any Error>
 }
 
@@ -224,20 +197,11 @@ public struct CommandRunner: CommandRunning, Sendable {
         #endif
     }
 
-    public func run(
-        arguments: [String],
-        environment: [String: String] = ProcessInfo.processInfo.environment,
-        workingDirectory: Path.AbsolutePath? = nil
-    ) -> AsyncThrowingStream<CommandEvent, any Error> {
-        run(arguments: arguments, environment: environment, workingDirectory: workingDirectory, output: .capture)
-    }
-
     // swiftlint:disable:next function_body_length
     public func run(
         arguments: [String],
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        workingDirectory: Path.AbsolutePath? = nil,
-        output: OutputRedirection = .capture
+        workingDirectory: Path.AbsolutePath? = nil
     ) -> AsyncThrowingStream<CommandEvent, any Error> {
         AsyncThrowingStream(CommandEvent.self, bufferingPolicy: .unbounded) { continuation in
             let runningProcess = ThreadSafe<Process?>(nil)
@@ -261,64 +225,41 @@ public struct CommandRunner: CommandRunning, Sendable {
 
                         // Process
                         let process = Process()
+                        let stdoutPipe = Pipe()
+                        let stderrPipe = Pipe()
 
-                        // Only allocate output pipes when the caller wants to capture output.
-                        // Discarding or inheriting avoids holding any extra file descriptors.
-                        let stdoutPipe: Pipe?
-                        let stderrPipe: Pipe?
-                        let stdoutTask: Task<Void, Never>?
-                        let stderrTask: Task<Void, Never>?
+                        let stdoutTask = Task {
+                            do {
+                                for try await data in stdoutPipe.fileHandleForReading.byteStream() {
+                                    continuation.yield(.standardOutput([UInt8](data)))
+                                    if let output = String(data: data, encoding: .utf8) {
+                                        logger?.debug("\(output)", metadata: loggerMetadata)
+                                    }
+                                }
+                            } catch {
+                                logger?.error("Error reading stdout: \(error)", metadata: loggerMetadata)
+                            }
+                        }
 
-                        switch output {
-                        case .capture:
-                            let outPipe = Pipe()
-                            let errPipe = Pipe()
-                            stdoutPipe = outPipe
-                            stderrPipe = errPipe
-                            process.standardOutput = outPipe
-                            process.standardError = errPipe
-                            stdoutTask = Task {
-                                do {
-                                    for try await data in outPipe.fileHandleForReading.byteStream() {
-                                        continuation.yield(.standardOutput([UInt8](data)))
-                                        if let output = String(data: data, encoding: .utf8) {
-                                            logger?.debug("\(output)", metadata: loggerMetadata)
-                                        }
+                        let stderrTask = Task {
+                            do {
+                                for try await data in stderrPipe.fileHandleForReading.byteStream() {
+                                    continuation.yield(.standardError([UInt8](data)))
+                                    if let output = String(data: data, encoding: .utf8) {
+                                        collectedStdErr.mutate { $0.append(output) }
+                                        logger?.error("\(output)", metadata: loggerMetadata)
                                     }
-                                } catch {
-                                    logger?.error("Error reading stdout: \(error)", metadata: loggerMetadata)
                                 }
+                            } catch {
+                                logger?.error("Error reading stderr: \(error)", metadata: loggerMetadata)
                             }
-                            stderrTask = Task {
-                                do {
-                                    for try await data in errPipe.fileHandleForReading.byteStream() {
-                                        continuation.yield(.standardError([UInt8](data)))
-                                        if let output = String(data: data, encoding: .utf8) {
-                                            collectedStdErr.mutate { $0.append(output) }
-                                            logger?.error("\(output)", metadata: loggerMetadata)
-                                        }
-                                    }
-                                } catch {
-                                    logger?.error("Error reading stderr: \(error)", metadata: loggerMetadata)
-                                }
-                            }
-                        case .discard:
-                            stdoutPipe = nil
-                            stderrPipe = nil
-                            stdoutTask = nil
-                            stderrTask = nil
-                            process.standardOutput = FileHandle.nullDevice
-                            process.standardError = FileHandle.nullDevice
-                        case .inherit:
-                            stdoutPipe = nil
-                            stderrPipe = nil
-                            stdoutTask = nil
-                            stderrTask = nil
                         }
 
                         if let workingDirectory {
                             process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory.pathString)
                         }
+                        process.standardOutput = stdoutPipe
+                        process.standardError = stderrPipe
                         process.standardInput = FileHandle.standardInput
                         process.environment = environment
 
@@ -351,11 +292,11 @@ public struct CommandRunner: CommandRunning, Sendable {
                             }
                         }
 
-                        await stdoutTask?.value
-                        await stderrTask?.value
+                        await stdoutTask.value
+                        await stderrTask.value
 
-                        try? stdoutPipe?.fileHandleForReading.close()
-                        try? stderrPipe?.fileHandleForReading.close()
+                        try? stdoutPipe.fileHandleForReading.close()
+                        try? stderrPipe.fileHandleForReading.close()
 
                         switch process.terminationReason {
                         case .exit:

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -204,7 +204,9 @@ public struct CommandRunner: CommandRunning, Sendable {
         workingDirectory: Path.AbsolutePath? = nil
     ) -> AsyncThrowingStream<CommandEvent, any Error> {
         AsyncThrowingStream(CommandEvent.self, bufferingPolicy: .unbounded) { continuation in
-            Task.detached {
+            let runningProcess = ThreadSafe<Process?>(nil)
+
+            let task = Task.detached {
                 do {
                     try await processLimiter.withPermit {
                         let loggerMetadata: Logger.Metadata = ["command": .string(arguments.joined(separator: " "))]
@@ -269,18 +271,9 @@ public struct CommandRunner: CommandRunning, Sendable {
 
                         logger?.debug("Running sub-process", metadata: loggerMetadata)
 
-                        let threadSafeProcess = ThreadSafe(process)
-
-                        continuation.onTermination = { termination in
-                            switch termination {
-                            case .cancelled:
-                                if threadSafeProcess.value.isRunning {
-                                    threadSafeProcess.value.terminate()
-                                }
-                            default:
-                                break
-                            }
-                        }
+                        // Publish the process so the stream's termination handler (installed before
+                        // the permit was awaited) can terminate it once it exists.
+                        runningProcess.mutate { $0 = process }
 
                         try await withCheckedThrowingContinuation { (processCompletion: CheckedContinuation<Void, any Error>) in
                             process.terminationHandler = { _ in
@@ -288,6 +281,11 @@ public struct CommandRunner: CommandRunning, Sendable {
                             }
                             do {
                                 try process.run()
+                                // Close the race where the stream is cancelled after the process is
+                                // published but before it started running.
+                                if Task.isCancelled {
+                                    process.terminate()
+                                }
                             } catch {
                                 process.terminationHandler = nil
                                 processCompletion.resume(throwing: error)
@@ -320,6 +318,22 @@ public struct CommandRunner: CommandRunning, Sendable {
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { termination in
+                switch termination {
+                case .cancelled:
+                    // Cancelling the producer task unwinds it whether it is still waiting for a
+                    // permit or already running the subprocess.
+                    task.cancel()
+                    runningProcess.withValue { process in
+                        if let process, process.isRunning {
+                            process.terminate()
+                        }
+                    }
+                default:
+                    break
                 }
             }
         }

--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -146,8 +146,19 @@ public enum CommandError: Error, CustomStringConvertible, LocalizedError, Sendab
 public struct CommandRunner: CommandRunning, Sendable {
     let logger: Logger?
 
+    /// Bounds the number of concurrently-running subprocesses so the pipe file descriptors they
+    /// hold can't exhaust the process's file-descriptor table.
+    private let processLimiter: AsyncResourceLimiter
+
     public init(logger: Logger? = nil) {
         self.logger = logger
+        processLimiter = Self.sharedProcessLimiter
+    }
+
+    /// Creates a runner with a custom cap on concurrently-running subprocesses.
+    init(logger: Logger? = nil, maximumConcurrentProcesses: Int) {
+        self.logger = logger
+        processLimiter = AsyncResourceLimiter(limit: maximumConcurrentProcesses)
     }
 
     /// File descriptors kept in reserve for stdio and other process-wide handles.
@@ -160,10 +171,9 @@ public struct CommandRunner: CommandRunning, Sendable {
     /// Used when the file-descriptor limit can't be determined.
     private static let fallbackMaximumConcurrentProcesses = 16
 
-    /// Bounds the number of concurrently-running subprocesses so the pipe file descriptors they
-    /// hold can't exhaust the process's file-descriptor table. The limit is derived from the
-    /// current soft `RLIMIT_NOFILE`, so it adapts if the limit is raised at startup.
-    private static let processLimiter = AsyncResourceLimiter(
+    /// Shared limiter whose cap is derived from the current soft `RLIMIT_NOFILE`, so it adapts if
+    /// the limit is raised at startup.
+    private static let sharedProcessLimiter = AsyncResourceLimiter(
         limitProvider: { systemMaximumConcurrentProcesses() }
     )
 
@@ -196,7 +206,7 @@ public struct CommandRunner: CommandRunning, Sendable {
         AsyncThrowingStream(CommandEvent.self, bufferingPolicy: .unbounded) { continuation in
             Task.detached {
                 do {
-                    try await Self.processLimiter.withPermit {
+                    try await processLimiter.withPermit {
                         let loggerMetadata: Logger.Metadata = ["command": .string(arguments.joined(separator: " "))]
                         // Resolve the working directory if not passed. `getcwd` can transiently
                         // return an empty path under concurrent process launches, so fall back to

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -1,9 +1,56 @@
+import Foundation
 import Mockable
 import Testing
 @testable import Command
 
 #if !os(Linux)
     struct CommandRunnerRaceTests {
+        @Test func boundsConcurrentSubprocessLaunches() async throws {
+            #if os(macOS)
+                // Each running subprocess holds open pipe file descriptors, so an unbounded fan-out
+                // can exhaust the process's file-descriptor table (surfacing as EBADF on launch).
+                // The runner must cap how many subprocesses run at once; verify that cap holds.
+                let limit = 4
+                let commandRunner = CommandRunner(maximumConcurrentProcesses: limit)
+
+                let directory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("command-limiter-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                defer { try? FileManager.default.removeItem(at: directory) }
+
+                // Each command creates a marker file while it runs and removes it on exit, so the
+                // number of marker files present at any instant equals the number of subprocesses
+                // running concurrently.
+                let maxObserved = ThreadSafe(0)
+                let sampler = Task {
+                    while !Task.isCancelled {
+                        let count = (try? FileManager.default.contentsOfDirectory(atPath: directory.path))?.count ?? 0
+                        maxObserved.mutate { $0 = max($0, count) }
+                        try? await Task.sleep(nanoseconds: 2_000_000)
+                    }
+                }
+
+                let script = "marker=\"\(directory.path)/$$\"; touch \"$marker\"; sleep 0.2; rm -f \"$marker\""
+                await withTaskGroup(of: Void.self) { group in
+                    for _ in 0 ..< 60 {
+                        group.addTask {
+                            do {
+                                for try await _ in commandRunner.run(arguments: ["/bin/sh", "-c", script]) {}
+                            } catch {}
+                        }
+                    }
+                    await group.waitForAll()
+                }
+                sampler.cancel()
+
+                #expect(maxObserved.value > 0, "Expected to observe running subprocesses")
+                #expect(
+                    maxObserved.value <= limit,
+                    "Observed \(maxObserved.value) concurrent subprocesses, expected at most \(limit)"
+                )
+            #endif
+        }
+
         @Test func runsManyConcurrent_successfully() async throws {
             #if os(Linux) || os(macOS)
                 let commandRunner = CommandRunner()

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -51,6 +51,54 @@ import Testing
             #endif
         }
 
+        @Test func cancellingWhileWaitingForPermit_doesNotLaunchSubprocess() async throws {
+            #if os(macOS)
+                // With a single permit, a second command is parked inside the limiter waiting for the
+                // permit. Cancelling its stream while it waits must unwind the producer so it never
+                // launches a subprocess once the permit frees up.
+                let commandRunner = CommandRunner(maximumConcurrentProcesses: 1)
+
+                let directory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("command-cancel-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                defer { try? FileManager.default.removeItem(at: directory) }
+
+                let holderMarker = directory.appendingPathComponent("holder-running")
+                let blockedSentinel = directory.appendingPathComponent("blocked-launched")
+
+                // Holds the only permit: signals it is running, then stays alive long enough for us to
+                // enqueue and cancel a second command while the permit is taken.
+                let holderScript = "touch \"\(holderMarker.path)\"; sleep 2; rm -f \"\(holderMarker.path)\""
+                let holder = Task {
+                    for try await _ in commandRunner.run(arguments: ["/bin/sh", "-c", holderScript]) {}
+                }
+
+                while !FileManager.default.fileExists(atPath: holderMarker.path) {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+
+                // This can only start once the permit frees. If it ever launches it creates the
+                // sentinel; because we cancel it while it is still waiting, the sentinel must never appear.
+                let blockedScript = "touch \"\(blockedSentinel.path)\""
+                let blocked = Task {
+                    for try await _ in commandRunner.run(arguments: ["/bin/sh", "-c", blockedScript]) {}
+                }
+
+                try await Task.sleep(nanoseconds: 100_000_000)
+                blocked.cancel()
+                _ = await blocked.result
+
+                // Release the permit and give any incorrectly-orphaned producer a chance to launch.
+                _ = try? await holder.value
+                try await Task.sleep(nanoseconds: 300_000_000)
+
+                #expect(
+                    !FileManager.default.fileExists(atPath: blockedSentinel.path),
+                    "A command cancelled while waiting for a permit must not launch a subprocess"
+                )
+            #endif
+        }
+
         @Test func runsManyConcurrent_successfully() async throws {
             #if os(Linux) || os(macOS)
                 let commandRunner = CommandRunner()

--- a/Tests/CommandTests/CommandRunnerTests.swift
+++ b/Tests/CommandTests/CommandRunnerTests.swift
@@ -22,6 +22,32 @@ import Testing
             #endif
         }
 
+        @Test func discardOutput_emitsNoEventsButStillRuns() async throws {
+            #if !os(Windows)
+                let commandRunner = CommandRunner()
+
+                // Capturing yields the command's output...
+                let captured = try await commandRunner.run(arguments: ["echo", "foo"], output: .capture)
+                    .reduce(into: [String]()) { $0.append($1.string() ?? "") }
+                #expect(captured == ["foo\n"])
+
+                // ...while discarding allocates no pipes and emits nothing, yet still runs.
+                let discardedEventCount = try await commandRunner.run(arguments: ["echo", "foo"], output: .discard)
+                    .reduce(into: 0) { count, _ in count += 1 }
+                #expect(discardedEventCount == 0)
+            #endif
+        }
+
+        @Test func discardOutput_stillReportsNonZeroExit() async throws {
+            #if !os(Windows)
+                let commandRunner = CommandRunner()
+
+                await #expect(throws: CommandError.self) {
+                    for try await _ in commandRunner.run(arguments: ["/bin/sh", "-c", "exit 7"], output: .discard) {}
+                }
+            #endif
+        }
+
         @Test func lookupExecutable_withAbsolutePath() throws {
             // Given
             let commandRunner = CommandRunner()

--- a/Tests/CommandTests/CommandRunnerTests.swift
+++ b/Tests/CommandTests/CommandRunnerTests.swift
@@ -22,32 +22,6 @@ import Testing
             #endif
         }
 
-        @Test func discardOutput_emitsNoEventsButStillRuns() async throws {
-            #if !os(Windows)
-                let commandRunner = CommandRunner()
-
-                // Capturing yields the command's output...
-                let captured = try await commandRunner.run(arguments: ["echo", "foo"], output: .capture)
-                    .reduce(into: [String]()) { $0.append($1.string() ?? "") }
-                #expect(captured == ["foo\n"])
-
-                // ...while discarding allocates no pipes and emits nothing, yet still runs.
-                let discardedEventCount = try await commandRunner.run(arguments: ["echo", "foo"], output: .discard)
-                    .reduce(into: 0) { count, _ in count += 1 }
-                #expect(discardedEventCount == 0)
-            #endif
-        }
-
-        @Test func discardOutput_stillReportsNonZeroExit() async throws {
-            #if !os(Windows)
-                let commandRunner = CommandRunner()
-
-                await #expect(throws: CommandError.self) {
-                    for try await _ in commandRunner.run(arguments: ["/bin/sh", "-c", "exit 7"], output: .discard) {}
-                }
-            #endif
-        }
-
         @Test func lookupExecutable_withAbsolutePath() throws {
             // Given
             let commandRunner = CommandRunner()


### PR DESCRIPTION
## What changed

Bound the number of concurrently-running subprocesses with an `AsyncResourceLimiter` (a cancellation-aware async semaphore), sized from the current soft `RLIMIT_NOFILE`. Each `CommandRunner.run` launch acquires a permit for the duration it holds its pipe file descriptors.

## Why

Every running subprocess holds open pipe file descriptors (stdout + stderr, plus the transient pipe used to locate the executable). Before #249, the blocking `waitUntilExit` kept a cooperative thread busy per launch, which implicitly capped how many subprocesses ran at once. #249 switched to an async wait (correctly fixing thread starvation) — but that removed the implicit bound, so a caller that fans out many concurrent commands can run the process out of file descriptors.

The failure surfaces as a raw `NSPOSIXErrorDomain Code=9 "Bad file descriptor"` from `Process.run()`. It's especially easy to hit on CI, where the default soft `RLIMIT_NOFILE` is low (256 on macOS). Reported downstream in Tuist: `tuist graph` on a very large project (the AWS SDK for iOS) aborts with exactly this error.

## The fix

`AsyncResourceLimiter` mirrors the pattern already used in [tuist/FileSystem](https://github.com/tuist/FileSystem) for bounding concurrent file operations:

- The limit is derived from the soft fd limit — `min(256, (softLimit - 32) / fdsPerProcess)` — so it adapts if the limit is raised at startup, and falls back to a safe default when the limit can't be read.
- It **suspends** waiters rather than blocking threads, so it does not reintroduce the thread starvation #249 fixed.

`CommandRunner` holds an instance limiter (defaulting to a shared, fd-derived one) so resource usage stays bounded regardless of how many commands a caller fans out, rather than relying on the ambient fd limit being high enough.

## Validation

**Committed regression test (red/green).** `CommandRunnerRaceTests.boundsConcurrentSubprocessLaunches` runs 60 commands through a runner capped at 4 and asserts that the number of subprocesses alive at any instant (observed via per-process marker files) never exceeds the cap:

- With the limiter bypassed: `Observed 60 concurrent subprocesses, expected at most 4` → **fails**.
- With the limiter: peak ≤ 4 → **passes**.

`swift build` and `swift test` pass (including the existing concurrency race suite).

**Symptom-level e2e (manual).** A standalone harness depending on this package, run as a fresh process with the soft fd limit forced to 256, reproduces the exact `NSPOSIXErrorDomain Code=9 "Bad file descriptor"` on the pre-fix code under a high-concurrency mix of large-output and short commands; with the limiter the same load completes with zero errors. (Out-of-suite because a `swift test` runner process doesn't enforce a lowered soft fd limit for new descriptors the way a fresh process does, so the committed test asserts the concurrency-bound invariant instead.)
