### PR TITLE
fix: Add capability to kill whole process

### DIFF
--- a/Sources/Command/CommandRunner.swift
+++ b/Sources/Command/CommandRunner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Logging
+
 // Mockable depends on Combine, which is only available on macOS.
 #if os(macOS)
     import Mockable
@@ -205,6 +206,22 @@ public struct CommandRunner: CommandRunning, Sendable {
     ) -> AsyncThrowingStream<CommandEvent, any Error> {
         AsyncThrowingStream(CommandEvent.self, bufferingPolicy: .unbounded) { continuation in
             let runningProcess = ThreadSafe<Process?>(nil)
+            let processGroupID = ThreadSafe<pid_t?>(nil)
+
+            @Sendable func terminateRunningProcess() {
+                runningProcess.withValue { process in
+                    guard let process, process.isRunning else { return }
+
+                    guard let groupID = processGroupID.value else {
+                        process.terminate()
+                        return
+                    }
+
+                    // Xcode can launch test runners and other helpers below xcodebuild. Kill the
+                    // process group immediately so cancellation cannot leave UI-test descendants behind.
+                    _ = kill(-groupID, SIGKILL)
+                }
+            }
 
             let task = Task.detached {
                 do {
@@ -281,10 +298,13 @@ public struct CommandRunner: CommandRunning, Sendable {
                             }
                             do {
                                 try process.run()
+                                if setpgid(process.processIdentifier, process.processIdentifier) == 0 {
+                                    processGroupID.mutate { $0 = process.processIdentifier }
+                                }
                                 // Close the race where the stream is cancelled after the process is
                                 // published but before it started running.
                                 if Task.isCancelled {
-                                    process.terminate()
+                                    terminateRunningProcess()
                                 }
                             } catch {
                                 process.terminationHandler = nil
@@ -327,11 +347,7 @@ public struct CommandRunner: CommandRunning, Sendable {
                     // Cancelling the producer task unwinds it whether it is still waiting for a
                     // permit or already running the subprocess.
                     task.cancel()
-                    runningProcess.withValue { process in
-                        if let process, process.isRunning {
-                            process.terminate()
-                        }
-                    }
+                    terminateRunningProcess()
                 default:
                     break
                 }

--- a/Tests/CommandTests/CommandRunnerRaceTests.swift
+++ b/Tests/CommandTests/CommandRunnerRaceTests.swift
@@ -99,6 +99,32 @@ import Testing
             #endif
         }
 
+        @Test func cancellingRunningProcess_terminatesItsProcessGroup() async throws {
+            #if os(macOS)
+                let commandRunner = CommandRunner()
+                let directory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("command-process-group-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                defer { try? FileManager.default.removeItem(at: directory) }
+
+                let processStarted = directory.appendingPathComponent("process-started")
+                let childEscaped = directory.appendingPathComponent("child-escaped")
+                let script = "touch \"\(processStarted.path)\"; sleep 0.5; touch \"\(childEscaped.path)\""
+                let processTask = Task {
+                    for try await _ in commandRunner.run(arguments: ["/bin/sh", "-c", script]) {}
+                }
+
+                while !FileManager.default.fileExists(atPath: processStarted.path) {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+                processTask.cancel()
+                _ = await processTask.result
+                try await Task.sleep(nanoseconds: 750_000_000)
+
+                #expect(!FileManager.default.fileExists(atPath: childEscaped.path))
+            #endif
+        }
+
         @Test func runsManyConcurrent_successfully() async throws {
             #if os(Linux) || os(macOS)
                 let commandRunner = CommandRunner()


### PR DESCRIPTION
I was running UITests via tuist cli and found out that if I cancel the UI tests, the tuist process gets killed and cleaned up but the UITests keeps running behind the scene. 

Apparently this does not happen if you are running unit tests. Seems like UITests spawns different processes and they all don't get the kill signal when tuist process gets killed.

Thus in this PR, I am adding the process to group process and then also killing it when the process gets a kill signal. 

For this code to work, I also needed to change things in the tuist cli so that it can forward the kill signal to the Command Package here. Here is the [PR](https://github.com/tuist/tuist/pull/12521) for that.

**How to reproduce this issue:**
Run UI tests from `tuist test` command and then when UI tests are executing kill the command by `Ctrl + c` . The tuist process will get killed but you will see that UI tests will keep running in the simulator. Open the `Activity Monitor` and you will find an xcodebuild process still alive. Kill that process and that would terminate the UI tests run.

